### PR TITLE
Fixes for the setup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:22.04
+RUN apt-get update
+RUN apt-get -qq -y install curl wget unzip zip perl bzip2 cpanminus
+RUN apt-get install -y openjdk-8-jdk
+RUN apt-get install -y openjdk-8-jre
+RUN update-alternatives --config java
+RUN update-alternatives --config javac
+RUN apt-get install -y python3 git
+RUN mkdir defects4j_mf
+WORKDIR defects4j_mf
+COPY defects4j_multi_with_jars.patch defects4j_multi_with_jars.patch
+COPY setup.py setup.py
+COPY fault_data/ fault_data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 RUN apt-get update
-RUN apt-get -qq -y install curl wget unzip zip perl bzip2 cpanminus
+RUN apt-get -qq -y install curl wget unzip zip perl bzip2 cpanminus gcc
 RUN apt-get install -y openjdk-8-jdk
 RUN apt-get install -y openjdk-8-jre
 RUN update-alternatives --config java
@@ -11,3 +11,5 @@ WORKDIR defects4j_mf
 COPY defects4j_multi_with_jars.patch defects4j_multi_with_jars.patch
 COPY setup.py setup.py
 COPY fault_data/ fault_data/
+RUN python3 setup.py
+RUN . /root/.bashrc

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,21 @@ path = os.getcwd()
 d4j_path = path + '/defects4j'
 
 if not os.path.isdir(d4j_path):
-    os.system('git clone git@github.com:rjust/defects4j.git')
+    os.system('git clone https://github.com/rjust/defects4j.git')
     os.chdir('defects4j')
     os.system('cpanm --installdeps .')
     os.system('./init.sh')
 else:
     os.chdir('defects4j')
 
+if os.path.isfile(os.path.join(os.environ['HOME'], ".bashrc")):
+    rcfile = open(os.path.join(os.environ['HOME'], ".bashrc"), "a")
+else:
+    rcfile = open(os.path.join(os.environ['HOME'], ".profile"), "a")
+rcfile.write('export D4J_HOME="{}"\n'.format(d4j_path))
+rcfile.write('export PATH="$PATH:$D4J_HOME/framework/bin"\n')
+rcfile.close()
+os.system('export D4J_HOME="{}"'.format(d4j_path))
 os.system('export PATH=$PATH:{}/framework/bin'.format(d4j_path))
 
 if '--check' in sys.argv:

--- a/setup.py
+++ b/setup.py
@@ -20,24 +20,24 @@ if not os.path.isdir(d4j_path):
     os.chdir('defects4j')
     os.system('cpanm --installdeps .')
     os.system('./init.sh')
+
+    if os.path.isfile(os.path.join(os.environ['HOME'], ".bashrc")):
+        rcfile = open(os.path.join(os.environ['HOME'], ".bashrc"), "a")
+    else:
+        rcfile = open(os.path.join(os.environ['HOME'], ".profile"), "a")
+    rcfile.write('export D4J_HOME="{}"\n'.format(d4j_path))
+    rcfile.write('export PATH="$PATH:$D4J_HOME/framework/bin"\n')
+    rcfile.close()
+    os.system('export PATH=$PATH:{}/framework/bin'.format(d4j_path))
 else:
     os.chdir('defects4j')
-
-if os.path.isfile(os.path.join(os.environ['HOME'], ".bashrc")):
-    rcfile = open(os.path.join(os.environ['HOME'], ".bashrc"), "a")
-else:
-    rcfile = open(os.path.join(os.environ['HOME'], ".profile"), "a")
-rcfile.write('export D4J_HOME="{}"\n'.format(d4j_path))
-rcfile.write('export PATH="$PATH:$D4J_HOME/framework/bin"\n')
-rcfile.close()
-os.system('export PATH=$PATH:{}/framework/bin'.format(d4j_path))
 
 if '--check' in sys.argv:
     # Check Defects4J installation
     lang = os.popen('defects4j info -p Lang').read()
     print(lang)
 
-os.system('git apply {}/defects4j_multi_with_jars.patch'.format(path))
+os.system('git apply {0} >/dev/null 2>&1'.format(os.path.join(path, "defects4j_multi_with_jars.patch")))
 os.system('export D4J_HOME={}'.format(d4j_path))
 os.chdir('..')
 
@@ -53,5 +53,6 @@ if '--check' in sys.argv:
             print("Multifault Defects4J correctly installed")
 
 os.chdir('fault_data')
-os.system('tar -xjf multi.tar.bz2')
-os.system('defects4j_multi configure -f {}/fault_data'.format(path))
+if (not os.path.isdir('multi')):
+    os.system('tar -xjf multi.tar.bz2')
+    os.system('defects4j_multi configure -f {}/fault_data'.format(path))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ else:
 rcfile.write('export D4J_HOME="{}"\n'.format(d4j_path))
 rcfile.write('export PATH="$PATH:$D4J_HOME/framework/bin"\n')
 rcfile.close()
-os.system('export D4J_HOME="{}"'.format(d4j_path))
 os.system('export PATH=$PATH:{}/framework/bin'.format(d4j_path))
 
 if '--check' in sys.argv:


### PR DESCRIPTION
Added the following:
* Fixed the cloning of the defects4j repository so that it doesn't require a ssh key
* Added the necessary exports to the rc file so that commands will be available after running setup.py
* Made the setup script re-runnable without errors or executing steps already done
* Added a dockerfile for setting up the repository