### PR TITLE
Fixed the setup script to patch correctly.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if version != '1.8':
     exit(-1)
 
 path = os.getcwd()
-d4j_path = path + '/defects4j'
+d4j_path = os.path.join(path, 'defects4j')
 
 if not os.path.isdir(d4j_path):
     os.system('git clone https://github.com/rjust/defects4j.git')
@@ -34,6 +34,11 @@ if not os.path.isdir(d4j_path):
     os.system('export PATH=$PATH:{}/framework/bin'.format(d4j_path))
 else:
     os.chdir('defects4j')
+    if (not os.path.samefile(os.getcwd(), d4j_path)):  # sanity check
+        os.chdir(d4j_path)
+    os.system('git reset 2>&1')
+    os.system('git restore . 2>&1')
+    os.system('git clean -dfx 2>&1')
 
 if '--check' in sys.argv:
     # Check Defects4J installation

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,9 @@ else:
     os.chdir('defects4j')
     if (not os.path.samefile(os.getcwd(), d4j_path)):  # sanity check
         os.chdir(d4j_path)
-    os.system('git reset 2>&1')
-    os.system('git restore . 2>&1')
-    os.system('git clean -dfx 2>&1')
+    os.system('git reset framework 2>&1')
+    os.system('git restore framework 2>&1')
+    os.system('git clean -dfx framework 2>&1')
 
 if '--check' in sys.argv:
     # Check Defects4J installation


### PR DESCRIPTION
[Details]
The setup script previously just git applied new changes for defects4j_multi on top of any existing changes to the defects4j repo. This however could conflict if the changes are incompatible. To fix this, the setup script was adapted to remove all current changes to the defects4j repo for the multi extension before re-applying them.

[File's changed]
	modified:   setup.py